### PR TITLE
Remove left padding; center .links

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -38,6 +38,8 @@ body {
       text-align: center;
 
       ul {
+        padding-left: 0;
+
         li {
           display: inline-block;
           list-syle: none;


### PR DESCRIPTION
The `ul` element for your `.links` still has the default padding associated with it, so it's bumping your links slightly off-kilter and to the right. This pull nukes the padding so that your links are nice and evenly centered on-screen.

/cc @amateurhuman

![](http://38.media.tumblr.com/9c5f13891610b87520ae16dd6a2aca31/tumblr_n72pez8q0v1r9d3blo1_500.gif)
